### PR TITLE
Make the in-repo UI DPI-aware

### DIFF
--- a/misc/AboutPanel.cs
+++ b/misc/AboutPanel.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using ImGuiNET;
+using RecompOne.Runtime.Host;
 using RecompOne.Runtime.Host.Window;
 
 namespace Recompiled;
@@ -22,7 +23,7 @@ public sealed class AboutPanel : IFloatingPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(340, 0), ImGuiCond.Always);
+        ImGui.SetNextWindowSize(new Vector2(340 * HostWindow.DpiScale, 0), ImGuiCond.Always);
         ImGui.SetNextWindowPos(ImGui.GetMainViewport().GetCenter(), ImGuiCond.Always, new Vector2(0.5f, 0.5f));
 
         bool open = IsOpen;

--- a/misc/AutoUpdater.cs
+++ b/misc/AutoUpdater.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ImGuiNET;
 using RecompOne.Runtime.Config;
+using RecompOne.Runtime.Host;
 using RecompOne.Runtime.Host.Window;
 
 namespace Recompiled;
@@ -309,8 +310,8 @@ public static class AutoUpdater //should be generic enough to use on other recom
 
         var vp = ImGui.GetMainViewport();
         ImGui.SetNextWindowPos(vp.GetCenter(), ImGuiCond.Appearing, new Vector2(0.5f, 0.5f));
-        ImGui.SetNextWindowSize(new Vector2(520, 430), ImGuiCond.Appearing);
-        ImGui.SetNextWindowSizeConstraints(new Vector2(420, 280), new Vector2(1000, 1000));
+        ImGui.SetNextWindowSize(new Vector2(520, 430) * HostWindow.DpiScale, ImGuiCond.Appearing);
+        ImGui.SetNextWindowSizeConstraints(new Vector2(420, 280) * HostWindow.DpiScale, new Vector2(1000, 1000) * HostWindow.DpiScale);
 
         bool open = true;
         bool visible = ImGui.Begin("Update", ref open,

--- a/misc/DiscCheck.cs
+++ b/misc/DiscCheck.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using System.Text;
 using ImGuiNET;
 using RecompOne.Runtime.Cdrom;
+using RecompOne.Runtime.Host;
 using RecompOne.Runtime.Host.Window;
 using RecompOne.Runtime.Memory;
 
@@ -102,7 +103,7 @@ public static class DiscCheck
 
         public void Draw()
         {
-            ImGui.SetNextWindowSize(new Vector2(420, 0), ImGuiCond.Always);
+            ImGui.SetNextWindowSize(new Vector2(420 * HostWindow.DpiScale, 0), ImGuiCond.Always);
             ImGui.SetNextWindowPos(ImGui.GetMainViewport().GetCenter(), ImGuiCond.Appearing, new Vector2(0.5f, 0.5f));
 
             bool open = true;

--- a/patches/cheats/InventoryCheatPanel.cs
+++ b/patches/cheats/InventoryCheatPanel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Numerics;
 using System.Text;
 using ImGuiNET;
+using RecompOne.Runtime.Host;
 using RecompOne.Runtime.Host.Window;
 using Sotn;
 
@@ -30,7 +31,7 @@ public sealed class InventoryCheatPanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(430, 560), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(430, 560) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open))
         {

--- a/patches/cheats/MovementCheatPanel.cs
+++ b/patches/cheats/MovementCheatPanel.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using ImGuiNET;
+using RecompOne.Runtime.Host;
 using RecompOne.Runtime.Host.Window;
 using Sotn;
 
@@ -15,7 +16,7 @@ public sealed class MovementCheatPanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(320, 420), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(320, 420) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open))
         {

--- a/patches/cheats/StatsCheatPanel.cs
+++ b/patches/cheats/StatsCheatPanel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 using ImGuiNET;
+using RecompOne.Runtime.Host;
 using RecompOne.Runtime.Host.Window;
 using RecompOne.Runtime.Memory;
 using Sotn;
@@ -16,7 +17,7 @@ public sealed class StatsCheatPanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(340, 500), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(340, 500) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open))
         {
@@ -84,14 +85,14 @@ public sealed class StatsCheatPanel : IPanel
     static void Slider(string label, Func<int> get, Action<int> set, int min, int max)
     {
         int v = get();
-        ImGui.SetNextItemWidth(190);
+        ImGui.SetNextItemWidth(190 * HostWindow.DpiScale);
         if (ImGui.SliderInt(label, ref v, min, max)) set(v);
     }
 
     static void Input(string label, Func<int> get, Action<int> set)
     {
         int v = get();
-        ImGui.SetNextItemWidth(130);
+        ImGui.SetNextItemWidth(130 * HostWindow.DpiScale);
         if (ImGui.InputInt(label, ref v)) set(Math.Max(0, v));
     }
 }

--- a/patches/qol/QualityOfLifePanel.cs
+++ b/patches/qol/QualityOfLifePanel.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using ImGuiNET;
+using RecompOne.Runtime.Host;
 using RecompOne.Runtime.Host.Window;
 
 namespace Recompiled;
@@ -11,7 +12,7 @@ public sealed class QualityOfLifePanel : IPanel
 
     public void Draw()
     {
-        ImGui.SetNextWindowSize(new Vector2(320, 420), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(320, 420) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open))
         {

--- a/patches/rando/RandoPanel.cs
+++ b/patches/rando/RandoPanel.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using ImGuiNET;
+using RecompOne.Runtime.Host;
 using RecompOne.Runtime.Host.Window;
 
 namespace Recompiled;
@@ -17,7 +18,7 @@ public sealed class RandoPanel : IPanel
         byte CurrentPreset = 0;
         byte StageId;
 
-        ImGui.SetNextWindowSize(new Vector2(320, 420), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(320, 420) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open))
         {

--- a/patches/tracker/MapOverlayPanel.cs
+++ b/patches/tracker/MapOverlayPanel.cs
@@ -61,7 +61,7 @@ public sealed class MapOverlayPanel : IPanel
     {
         EnsureLoaded();
 
-        ImGui.SetNextWindowSize(new Vector2(660, 560), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(660, 560) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open))
         {
@@ -98,7 +98,7 @@ public sealed class MapOverlayPanel : IPanel
     {
         ImGui.Text($"Castle {_curCastle}");
         ImGui.SameLine();
-        ImGui.SetNextItemWidth(140f);
+        ImGui.SetNextItemWidth(140f * HostWindow.DpiScale);
         if (ImGui.Combo("Checks", ref _checkSet, CheckSetNames, CheckSetNames.Length)) Persist();
         ImGui.SameLine();
         if (ImGui.SmallButton("Reset"))

--- a/patches/tracker/TrackerOverlayPanel.cs
+++ b/patches/tracker/TrackerOverlayPanel.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Numerics;
 using ImGuiNET;
+using RecompOne.Runtime.Host;
 using RecompOne.Runtime.Host.Window;
 using RecompOne.Runtime.Memory;
 
@@ -27,7 +28,7 @@ public sealed class TrackerOverlayPanel : IPanel
     {
         EnsureLoaded();
 
-        ImGui.SetNextWindowSize(new Vector2(300, 520), ImGuiCond.FirstUseEver);
+        ImGui.SetNextWindowSize(new Vector2(300, 520) * HostWindow.DpiScale, ImGuiCond.FirstUseEver);
         bool open = IsOpen;
         if (!ImGui.Begin(Name, ref open, ImGuiWindowFlags.MenuBar))
         {
@@ -104,7 +105,7 @@ public sealed class TrackerOverlayPanel : IPanel
             if (ImGui.MenuItem("JP exclusives", null, ref _showJp)) Persist();
             if (ImGui.MenuItem("Hand Items", null, ref _showHand)) Persist();
             if (ImGui.MenuItem("Body Items", null, ref _showBody)) Persist();
-            ImGui.SetNextItemWidth(140f);
+            ImGui.SetNextItemWidth(140f * HostWindow.DpiScale);
             if (ImGui.SliderInt("Columns", ref _columns, 1, 12))
                 _columns = Math.Clamp(_columns, 1, 12);
             if (ImGui.IsItemDeactivatedAfterEdit()) Persist();
@@ -180,7 +181,7 @@ public sealed class TrackerOverlayPanel : IPanel
         bool active = Tracker.IsActive(m, e);
 
         float cell = ImGui.GetContentRegionAvail().X;
-        float dim = _fixedIconSize ? FixedIconDim : MathF.Max(8f, cell * (1f - IconPadding));
+        float dim = _fixedIconSize ? FixedIconDim * HostWindow.DpiScale : MathF.Max(8f, cell * (1f - IconPadding));
         var size = new Vector2(dim, dim);
 
         ImGui.BeginGroup();


### PR DESCRIPTION
## Summary

Part of a 3-repo DPI-awareness fix for high-DPI monitors (tested at 225%
scaling, where the UI previously opened tiny and several buttons clipped
their own label text):

- BlackLabelHQ/RecompOne#8 — adds `HostWindow.DpiScale` (queried from the
  monitor's real content scale via GLFW) and fixes the host window +
  ImGui font/style scaling itself. This is the dependency the other two
  PRs build on.
- BlackLabelHQ/ShaderMod#1 — scales the shader mod's combo box width.
- This PR — scales every other hardcoded `Vector2`/`ItemWidth` literal
  living in this repo: cheat panels (Stats/Movement/Inventory), the
  tracker and map overlays, the randomizer panel, the QoL panel, the
  About panel, the disc/region validator popup, and the auto-updater
  window.

**Merge order / build note:** this PR's code references `HostWindow.DpiScale`,
which doesn't exist yet in the currently-pinned `RecompOne` submodule commit
(I deliberately left the submodule pointers in this PR unchanged rather than
pointing them at my own fork's branches). That means this PR will not compile
as-is until BlackLabelHQ/RecompOne#8 is merged and the `RecompOne` submodule
pointer here is bumped to include it — same for the `mods` submodule pointer
once BlackLabelHQ/ShaderMod#1 merges. Happy to handle those pointer bumps
myself once the other two land, whichever's easier on your end.

No-op at 100% display scaling — this only changes anything once
`HostWindow.DpiScale` is non-1, which only happens on a scaled monitor.

## Test plan

- [x] Built and ran alongside the RecompOne PR at 225% Windows scaling —
      every panel/popup in this repo now sizes and renders correctly,
      no more clipped button text
- [x] Confirmed unaffected at 100% scale