### PR TITLE
Added Minotaur and Werewolf Crash Fix

### DIFF
--- a/config/sotn.json
+++ b/config/sotn.json
@@ -2160,6 +2160,12 @@
       "target": "Recompiled.FunctionFixes.ClockCollisionFix"
     },
     {
+      "overlay": "bo2",
+      "function": "func_801A6EF8",
+      "mode": "pre",
+      "target": "Recompiled.FunctionFixes.MinotaurAndWerewolfFix"
+    },
+    {
       "overlay": "dra",
       "function": "func_80118C28",
       "mode": "pre",

--- a/patches/qol/FunctionFixes.cs
+++ b/patches/qol/FunctionFixes.cs
@@ -70,5 +70,25 @@ public static partial class FunctionFixes
             }
         }
     }
+
+    // Fix Minotaur & Werewolf Crash when entering from the right using Bat
+    // Hook func_801A6EF8 in bo2
+    public static void MinotaurAndWerewolfFix(CpuContext c, IMemory m)
+    {
+        if (QualityOfLife.BugFixes == false)
+            return;
+
+        byte Step = m.ReadU8(0x80077A84);
+        UInt16 PlayerStep = m.ReadU16(0x80073404);
+        UInt16 PlayerPosX = m.ReadU16(0x800733DA);
+
+        if (Step < 4 && PlayerPosX > 0x40 && (PlayerStep == 5 || PlayerStep == 0x18 || PlayerStep == 0x19))
+        {
+            m.WriteU16(0x80073404, 0);
+            m.WriteU16(0x80073406, 0);
+            m.WriteU16(0x800733EE, 0x8100);
+            m.WriteU16(0x800733F0, 0);
+        }
+    }
 }
 


### PR DESCRIPTION
When entering the boss fight from the right side if you transform into Wolf or Bat before moving to the left you could crash the game. This is fixed by this update. Normally this is only possible with glitches or in randomizer.